### PR TITLE
Decode OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,34 @@
-FROM dyne/zenroom:0.8.1
-FROM ubuntu:16.04
+# This Dockerfile creates an image based on Decode OS: https://hub.docker.com/r/dyne/decodeos
+# With Chainspace installed: https://github.com/DECODEproject/chainspace
+#
+# Save this into a file named "Dockerfile"
+#
+# build with:
+# docker build . -t  dyne/decodeos:latest
+#
+# run with:
+# docker run -it -p 9001:9001 -p 8081:8081 -p 19999:19999 dyne/decodeos:latest
+#
+#Then connect to the web interfaces to monitor the functioning of DECODE OS:
+#- http://localhost:9001 to supervise the daemons running and their logs
+#- http://localhost:8081 to access the values stored
+#- http://localhost:19999 to monitor the resource usage
+
+
+FROM dyne/zenroom:latest
+FROM dyne/decodeos:latest
+FROM python:2
 
 RUN apt-get update && \
 	apt-get install -y openjdk-8-jdk && \
-	apt-get install -y virtualenv tree python python-setuptools wget gzip \
-                           build-essential libssl-dev libffi-dev python-dev && \
+	apt-get install -y virtualenv tree python python-setuptools wget gzip nano \
+                           build-essential libssl1.0-dev libffi-dev python-dev && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*;
 
 COPY --from=0 /code/zenroom/src/zenroom-static /usr/bin/zenroom
 COPY --from=0 /code/zenroom/examples/elgamal  /opt/contracts/
+
 
 RUN easy_install pip
 
@@ -17,10 +36,12 @@ WORKDIR /app
 
 RUN virtualenv .chainspace.env
 RUN . .chainspace.env/bin/activate && pip install -U setuptools
-RUN . .chainspace.env/bin/activate && pip install petlib numpy bplib coconut-lib
+                        RUN . .chainspace.env/bin/activate && pip install petlib numpy bplib coconut-lib
 
+RUN wget https://sdk.dyne.org:4443/job/chainspace-jar/lastSuccessfulBuild/artifact/target/chainspace-bin-vSNAPSHOT.tgz
 
-COPY target/chainspace-bin-vSNAPSHOT.tgz /app/
+#RUN ls
+#COPY chainspace-bin-vSNAPSHOT.tgz /app/
 
 WORKDIR /app/chainspace
 
@@ -30,8 +51,3 @@ WORKDIR /app
 
 RUN . .chainspace.env/bin/activate && pip install -e chainspace/lib/chainspaceapi
 RUN . .chainspace.env/bin/activate && pip install -e chainspace/lib/chainspacecontract
-
-
-
-
-


### PR DESCRIPTION
The Dockerfile now loads  Decode OS, wget Chainspace from dyne's ci, install the latest Zenroom, contains Decode OS instructions, installs libssl1.0-dev